### PR TITLE
fix: run key

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -119,6 +119,8 @@ services:
     container_name: datanode1
     hostname: datanode1
     user: root
+    ports:
+    - "9864:9864"
     environment:
       - HADOOP_HOME=/opt/hadoop
     volumes:
@@ -137,6 +139,8 @@ services:
     container_name: datanode2
     hostname: datanode2
     user: root
+    ports:
+    - "9865:9864"
     environment:
       - HADOOP_HOME=/opt/hadoop
     volumes:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -21,4 +21,4 @@ ensure() {
 }
 
 ensure broker-1 weather_raw_topic
-ensure broker-1 weather_10min_avg
+ensure broker-1 weather_60min_avg

--- a/streaming/init.sql
+++ b/streaming/init.sql
@@ -38,8 +38,8 @@
       sys->sunset             AS sys_sunset
     FROM weather_raw_stream;
 
-  CREATE TABLE weather_10min_avg
-    WITH (KAFKA_TOPIC='weather_10min_avg', VALUE_FORMAT='JSON') AS
+  CREATE TABLE weather_60min_avg
+    WITH (KAFKA_TOPIC='weather_60min_avg', VALUE_FORMAT='JSON') AS
   SELECT
     'global-key' AS global_key,
     AVG(main_temp) AS avg_temp,
@@ -47,7 +47,7 @@
     AVG(main_humidity) AS avg_humidity,
     AVG(wind_speed) AS avg_wind_speed
   FROM weather_flat_stream
-  WINDOW TUMBLING (SIZE 10 MINUTES)
+  WINDOW TUMBLING (SIZE 60 MINUTES)
   GROUP BY 'global-key';  -- use a dummy key for single-partition stats
   ",
   "streamsProperties": {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Exposed web UI ports for Hadoop datanode services, allowing external access to datanode1 and datanode2 interfaces.

- **Improvements**
  - Adjusted weather data aggregation to use a 60-minute window instead of 10 minutes, with updated table and topic names to reflect this change.
  - Modified scheduling of weather data processing to run every 5 minutes instead of every minute, ensuring unique run identifiers for each location and run.

- **Bug Fixes**
  - Updated Kafka topic references to align with the new 60-minute aggregation window.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->